### PR TITLE
[3.14] GH-134774: fix 'Py_DEBUG': macro redefinition warnings for Windows debug builds

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-05-27-17-04-20.gh-issue-134774.CusyjW.rst
+++ b/Misc/NEWS.d/next/Build/2025-05-27-17-04-20.gh-issue-134774.CusyjW.rst
@@ -1,0 +1,2 @@
+Fix :c:macro:`Py_DEBUG` macro redefinition warnings on Windows debug builds.
+Patch by Chris Eibl.

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -94,11 +94,6 @@ WIN32 is still required for the locale module.
 #endif
 #endif /* Py_BUILD_CORE || Py_BUILD_CORE_BUILTIN || Py_BUILD_CORE_MODULE */
 
-/* _DEBUG implies Py_DEBUG */
-#ifdef _DEBUG
-#  define Py_DEBUG 1
-#endif
-
 /* Define to 1 when compiling for experimental free-threaded builds */
 #ifdef Py_GIL_DISABLED
 /* We undefine if it was set to zero because all later checks are #ifdef.


### PR DESCRIPTION
Since PR https://github.com/python/cpython/pull/134211 / issue https://github.com/python/cpython/issues/133779 was packported to 3.14, Windows debug builds show more than thousand such warnings:
```
pyconfig.h(390,16): warning C4005: 'Py_DEBUG': macro redefinition
```

This stems from
https://github.com/python/cpython/blob/b6e624a3fcd94600cbc1062cd13b0abbe56f0c25/PC/pyconfig.h#L97-L100
which got added in the above PR, but rather belong to PR https://github.com/python/cpython/pull/131944 / issue https://github.com/python/cpython/issues/131942 and should just be deleted.
